### PR TITLE
  Edit New issue Rename delegate method "ImageCropViewController"

### DIFF
--- a/ImageCropView/ImageCropView.h
+++ b/ImageCropView/ImageCropView.h
@@ -89,7 +89,7 @@ typedef struct {
 #pragma mark ImageCropViewController interface
 @protocol ImageCropViewControllerDelegate <NSObject>
 
-- (void)ImageCropViewController:(UIViewController* )controller didFinishCroppingImage:(UIImage *)croppedImage;
+- (void)ImageCropViewControllerSuccess:(UIViewController* )controller didFinishCroppingImage:(UIImage *)croppedImage;
 - (void)ImageCropViewControllerDidCancel:(UIViewController *)controller;
 
 @end

--- a/ImageCropView/ImageCropView.m
+++ b/ImageCropView/ImageCropView.m
@@ -73,7 +73,7 @@ float IMAGE_MIN_WIDTH = 400;
 - (IBAction)done:(id)sender
 {
     
-    if ([self.delegate respondsToSelector:@selector(ImageCropViewController:didFinishCroppingImage:)])
+    if ([self.delegate respondsToSelector:@selector(ImageCropViewControllerSuccess:didFinishCroppingImage:)])
     {
         UIImage *cropped;
         if (self.image != nil){
@@ -82,7 +82,7 @@ float IMAGE_MIN_WIDTH = 400;
             cropped = [UIImage imageWithCGImage:imageRef];
             CGImageRelease(imageRef);
         }
-        [self.delegate ImageCropViewController:self didFinishCroppingImage:cropped];
+        [self.delegate ImageCropViewControllerSuccess:self didFinishCroppingImage:cropped];
     }
     
 }


### PR DESCRIPTION
After implement `ImageCropViewControllerDelegate` those 2 names collide each other, I'm using swift.