### PR TITLE
Remove a crop area set that is not needed. This confuses debugging.

### DIFF
--- a/ImageCropView/ImageCropView.m
+++ b/ImageCropView/ImageCropView.m
@@ -275,7 +275,6 @@ CGRect SquareCGRectAtCenter(CGFloat centerX, CGFloat centerY, CGFloat size) {
     [self addSubview:bottomLeftPoint];
     
     PointsArray = [[NSArray alloc] initWithObjects:topRightPoint, bottomRightPoint, topLeftPoint, bottomLeftPoint, nil];
-    [self.shadeView setCropArea:cropArea];
     
     self.maskAlpha = DEFAULT_MASK_ALPHA;
     


### PR DESCRIPTION
The actual one is at
https://github.com/myang-git/iOS-Image-Crop-View/blob/master/ImageCropView/ImageCropView.m#L762
This cost me some time to debug to figure out.

So I removed it hoping next person does not need to go through what I went through.