### PR TITLE
Change baseline view to remove warnings

### DIFF
--- a/ImageCropView/ImageCropView.m
+++ b/ImageCropView/ImageCropView.m
@@ -263,7 +263,7 @@ CGRect SquareCGRectAtCenter(CGFloat centerX, CGFloat centerY, CGFloat size) {
     dragRecognizer.view.multipleTouchEnabled = YES;
     dragRecognizer.minimumNumberOfTouches = 1;
     dragRecognizer.maximumNumberOfTouches = 2;
-    [self.viewForBaselineLayout addGestureRecognizer:dragRecognizer];
+    [self.viewForFirstBaselineLayout addGestureRecognizer:dragRecognizer];
     
     [self addSubview:imageView];
     [self addSubview:self.shadeView];


### PR DESCRIPTION
iOS 9 has deprecated viewForBaselineLayout, and it should be replaced with viewForFirstBaselineLayout.
